### PR TITLE
Refactor: Update LSP config and DX

### DIFF
--- a/after/plugin/lsp.lua
+++ b/after/plugin/lsp.lua
@@ -2,9 +2,6 @@
 -- ║ NeoVim LSP setup:                                                     ║
 -- ╚═══════════════════════════════════════════════════════════════════════╝
 
--- Adds a border to the `:LspInfo` and other windows.
-require('lspconfig.ui.windows').default_options.border = 'single'
-
 -- ╔═══════════════════════════════════════════════════════════════════════╗
 -- ║ Per-language LSP setup:                                               ║
 -- ╚═══════════════════════════════════════════════════════════════════════╝

--- a/after/plugin/lsp.lua
+++ b/after/plugin/lsp.lua
@@ -56,6 +56,9 @@ lspconfig.nil_ls.setup {
   },
 }
 
+-- Python
+lspconfig.pyright.setup{}
+
 -- Typescript
 lspconfig.ts_ls.setup {
   -- Prevent attachment into a Deno project.

--- a/after/plugin/lsp.lua
+++ b/after/plugin/lsp.lua
@@ -85,13 +85,13 @@ lspconfig.lua_ls.setup {
           -- Make the server aware of Neovim runtime files
           workspace = {
             checkThirdParty = false,
-            library = {
-              vim.env.VIMRUNTIME
-              -- "${3rd}/luv/library"
-              -- "${3rd}/busted/library",
-            }
+            -- library = {
+            --   vim.env.VIMRUNTIME
+            --   -- "${3rd}/luv/library"
+            --   -- "${3rd}/busted/library",
+            -- }
             -- or pull in all of 'runtimepath'. NOTE: this is a lot slower
-            -- library = vim.api.nvim_get_runtime_file("", true)
+            library = vim.api.nvim_get_runtime_file("", true)
           }
         }
       })

--- a/after/plugin/lsp.lua
+++ b/after/plugin/lsp.lua
@@ -27,7 +27,7 @@ lspconfig_defaults.capabilities = vim.tbl_deep_extend(
 vim.api.nvim_create_autocmd('LspAttach', {
   desc = 'LSP actions',
   callback = function(event)
-    local opts = {buffer = event.buf}
+    local opts = { buffer = event.buf }
 
     vim.keymap.set('n', 'K', '<cmd>lua vim.lsp.buf.hover()<cr>', opts)
     vim.keymap.set('n', 'gd', '<cmd>lua vim.lsp.buf.definition()<cr>', opts)
@@ -37,7 +37,7 @@ vim.api.nvim_create_autocmd('LspAttach', {
     vim.keymap.set('n', 'gr', '<cmd>lua vim.lsp.buf.references()<cr>', opts)
     vim.keymap.set('n', 'gs', '<cmd>lua vim.lsp.buf.signature_help()<cr>', opts)
     vim.keymap.set('n', '<F2>', '<cmd>lua vim.lsp.buf.rename()<cr>', opts)
-    vim.keymap.set({'n', 'x'}, '<F3>', '<cmd>lua vim.lsp.buf.format({async = true})<cr>', opts)
+    vim.keymap.set({ 'n', 'x' }, '<F3>', '<cmd>lua vim.lsp.buf.format({async = true})<cr>', opts)
     vim.keymap.set('n', '<F4>', '<cmd>lua vim.lsp.buf.code_action()<cr>', opts)
     vim.keymap.set('n', '<leader>rn', vim.lsp.buf.rename, opts)
   end,
@@ -76,10 +76,10 @@ lspconfig.nil_ls.setup {
 }
 
 -- Python
-lspconfig.pyright.setup{}
+lspconfig.pyright.setup {}
 
 -- Tailwind
-require'lspconfig'.tailwindcss.setup{}
+require 'lspconfig'.tailwindcss.setup {}
 
 
 -- Typescript

--- a/after/plugin/lsp.lua
+++ b/after/plugin/lsp.lua
@@ -35,11 +35,14 @@ lspconfig.elixirls.setup {
   cmd = { "elixir-ls" }
 }
 
-lspconfig.denols.setup {
-  -- Prevent attachment into a Node project.
-  -- See https://docs.deno.com/runtime/manual/getting_started/setup_your_environment#neovim-06-using-the-built-in-language-server
-  root_dir = lspconfig.util.root_pattern("deno.json", "deno.jsonc"),
-}
+if vim.fn.executable("deno") == 1 then -- Skip if deno is not on the dev env.
+  lspconfig.denols.setup {
+    -- Prevent attachment into a Node project.
+    -- See https://docs.deno.com/runtime/manual/getting_started/setup_your_environment#neovim-06-using-the-built-in-language-server
+    root_dir = lspconfig.util.root_pattern("deno.json", "deno.jsonc"),
+  }
+end
+
 
 require 'lspconfig'.gopls.setup {}
 

--- a/after/plugin/lsp.lua
+++ b/after/plugin/lsp.lua
@@ -59,6 +59,10 @@ lspconfig.nil_ls.setup {
 -- Python
 lspconfig.pyright.setup{}
 
+-- Tailwind
+require'lspconfig'.tailwindcss.setup{}
+
+
 -- Typescript
 lspconfig.ts_ls.setup {
   -- Prevent attachment into a Deno project.

--- a/after/plugin/lsp.lua
+++ b/after/plugin/lsp.lua
@@ -2,20 +2,6 @@
 -- ║ NeoVim LSP setup:                                                     ║
 -- ╚═══════════════════════════════════════════════════════════════════════╝
 
--- LSP-Zero setup guide:
--- https://github.com/VonHeikemen/lsp-zero.nvim#quickstart-for-the-impatient
---
--- Configuration options for LSP servers with official support:
--- https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md
-
-local lsp_zero = require('lsp-zero')
-
-lsp_zero.on_attach(function(_, bufnr) -- Ignored first argument `client`.
-  -- see :help lsp-zero-keybindings
-  -- to learn the available actions
-  lsp_zero.default_keymaps({ buffer = bufnr })
-end)
-
 -- Adds a border to the `:LspInfo` and other windows.
 require('lspconfig.ui.windows').default_options.border = 'single'
 
@@ -24,12 +10,6 @@ require('lspconfig.ui.windows').default_options.border = 'single'
 -- ╚═══════════════════════════════════════════════════════════════════════╝
 
 local lspconfig = require('lspconfig')
-
-lsp_zero.setup_servers({
-  'rust_analyzer', -- Installed by my Rust provisioning script.
-  'vimls',         -- Optionally installed by my NeoVim setup script.
-  'clojure_lsp',   -- Add `clojure-lsp` to Nix development shell.
-})
 
 lspconfig.elixirls.setup {
   cmd = { "elixir-ls" }
@@ -111,16 +91,11 @@ lspconfig.lua_ls.setup {
 -- ╚═══════════════════════════════════════════════════════════════════════╝
 
 local cmp = require('cmp')
-local cmp_action = require('lsp-zero').cmp_action()
 
 cmp.setup({
   mapping = cmp.mapping.preset.insert({
     -- `Enter` key to confirm completion
     ['<CR>'] = cmp.mapping.confirm({ select = false }),
-
-    -- Navigate between snippet placeholder
-    ['<C-f>'] = cmp_action.luasnip_jump_forward(),
-    ['<C-b>'] = cmp_action.luasnip_jump_backward(),
 
     -- Scroll up and down in the completion documentation
     ['<C-u>'] = cmp.mapping.scroll_docs(-4),

--- a/after/plugin/lsp.lua
+++ b/after/plugin/lsp.lua
@@ -2,6 +2,25 @@
 -- ║ NeoVim LSP setup:                                                     ║
 -- ╚═══════════════════════════════════════════════════════════════════════╝
 
+-- BEFORE WE CONFIGURE ANY LANGUAGE SERVER, we have to patch the default
+-- capabilities table from NeoVim's LSP with the extended completion
+-- capabilities that `cmp_nvim_lsp` has to offer.
+--
+-- > Language servers provide different completion results depending on the
+-- > capabilities of the client. Neovim's default omnifunc has basic support
+-- > for serving completion candidates. nvim-cmp supports more types of
+-- > completion candidates, so users must override the capabilities sent to
+-- > the server such that it can provide these candidates during a completion
+-- > request.
+-- >
+-- > Source: https://github.com/hrsh7th/cmp-nvim-lsp
+local lspconfig_defaults = require('lspconfig').util.default_config
+lspconfig_defaults.capabilities = vim.tbl_deep_extend(
+  'force',
+  lspconfig_defaults.capabilities,
+  require('cmp_nvim_lsp').default_capabilities()
+)
+
 -- ╔═══════════════════════════════════════════════════════════════════════╗
 -- ║ Per-language LSP setup:                                               ║
 -- ╚═══════════════════════════════════════════════════════════════════════╝

--- a/after/plugin/lsp.lua
+++ b/after/plugin/lsp.lua
@@ -40,6 +40,9 @@ vim.api.nvim_create_autocmd('LspAttach', {
     vim.keymap.set({ 'n', 'x' }, '<F3>', '<cmd>lua vim.lsp.buf.format({async = true})<cr>', opts)
     vim.keymap.set('n', '<F4>', '<cmd>lua vim.lsp.buf.code_action()<cr>', opts)
     vim.keymap.set('n', '<leader>rn', vim.lsp.buf.rename, opts)
+
+    vim.keymap.set('n', '[d', vim.diagnostic.goto_prev)
+    vim.keymap.set('n', ']d', vim.diagnostic.goto_next)
   end,
 })
 

--- a/after/plugin/lsp.lua
+++ b/after/plugin/lsp.lua
@@ -39,7 +39,7 @@ vim.api.nvim_create_autocmd('LspAttach', {
     vim.keymap.set('n', '<F2>', '<cmd>lua vim.lsp.buf.rename()<cr>', opts)
     vim.keymap.set({'n', 'x'}, '<F3>', '<cmd>lua vim.lsp.buf.format({async = true})<cr>', opts)
     vim.keymap.set('n', '<F4>', '<cmd>lua vim.lsp.buf.code_action()<cr>', opts)
-    vim.keymap.set('n', 'rn', vim.lsp.buf.rename, opts)
+    vim.keymap.set('n', '<leader>rn', vim.lsp.buf.rename, opts)
   end,
 })
 

--- a/after/plugin/lsp.lua
+++ b/after/plugin/lsp.lua
@@ -39,6 +39,7 @@ vim.api.nvim_create_autocmd('LspAttach', {
     vim.keymap.set('n', '<F2>', '<cmd>lua vim.lsp.buf.rename()<cr>', opts)
     vim.keymap.set({'n', 'x'}, '<F3>', '<cmd>lua vim.lsp.buf.format({async = true})<cr>', opts)
     vim.keymap.set('n', '<F4>', '<cmd>lua vim.lsp.buf.code_action()<cr>', opts)
+    vim.keymap.set('n', 'rn', vim.lsp.buf.rename, opts)
   end,
 })
 

--- a/after/plugin/lsp.lua
+++ b/after/plugin/lsp.lua
@@ -28,7 +28,6 @@ local lspconfig = require('lspconfig')
 lsp_zero.setup_servers({
   'rust_analyzer', -- Installed by my Rust provisioning script.
   'vimls',         -- Optionally installed by my NeoVim setup script.
-  'eslint',        -- `npm i -g vscode-langservers-extracted` (provided by my sdk_typescript role)
   'clojure_lsp',   -- Add `clojure-lsp` to Nix development shell.
 })
 

--- a/after/plugin/lsp.lua
+++ b/after/plugin/lsp.lua
@@ -21,6 +21,28 @@ lspconfig_defaults.capabilities = vim.tbl_deep_extend(
   require('cmp_nvim_lsp').default_capabilities()
 )
 
+
+-- These configurations only apply to buffers where there is an active language
+-- server.
+vim.api.nvim_create_autocmd('LspAttach', {
+  desc = 'LSP actions',
+  callback = function(event)
+    local opts = {buffer = event.buf}
+
+    vim.keymap.set('n', 'K', '<cmd>lua vim.lsp.buf.hover()<cr>', opts)
+    vim.keymap.set('n', 'gd', '<cmd>lua vim.lsp.buf.definition()<cr>', opts)
+    vim.keymap.set('n', 'gD', '<cmd>lua vim.lsp.buf.declaration()<cr>', opts)
+    vim.keymap.set('n', 'gi', '<cmd>lua vim.lsp.buf.implementation()<cr>', opts)
+    vim.keymap.set('n', 'go', '<cmd>lua vim.lsp.buf.type_definition()<cr>', opts)
+    vim.keymap.set('n', 'gr', '<cmd>lua vim.lsp.buf.references()<cr>', opts)
+    vim.keymap.set('n', 'gs', '<cmd>lua vim.lsp.buf.signature_help()<cr>', opts)
+    vim.keymap.set('n', '<F2>', '<cmd>lua vim.lsp.buf.rename()<cr>', opts)
+    vim.keymap.set({'n', 'x'}, '<F3>', '<cmd>lua vim.lsp.buf.format({async = true})<cr>', opts)
+    vim.keymap.set('n', '<F4>', '<cmd>lua vim.lsp.buf.code_action()<cr>', opts)
+  end,
+})
+
+
 -- ╔═══════════════════════════════════════════════════════════════════════╗
 -- ║ Per-language LSP setup:                                               ║
 -- ╚═══════════════════════════════════════════════════════════════════════╝

--- a/after/plugin/luasnip.lua
+++ b/after/plugin/luasnip.lua
@@ -20,7 +20,9 @@ luasnip.add_snippets("nix", {
   let
     cfg = config.{};
   in {{
-    options.{} = {{ enable = lib.mkEnableOption "{}"; }};
+    options.{} = {{
+      enable = lib.mkEnableOption "{}";
+    }};
 
     config = lib.mkIf cfg.enable {{
       {}

--- a/init.vim
+++ b/init.vim
@@ -144,27 +144,15 @@ Plug 'junegunn/vim-easy-align'
 " ║ LSP                                                                    ║
 " ╚════════════════════════════════════════════════════════════════════════╝
 
-" The plugin `lsp-zero` provides a no-brainer setup for LSP on neovim.
-"
-" All the settings related to LSP should be set together at
-" `after/plugin/lsp.lua`.
-"
-" Troubleshooting:
-" ----------------
-"
-" On a buffer, use `:LspInfo` to check if pertinent LSP server is actually
-" running.
-
-Plug 'L3MON4D3/LuaSnip', {'tag': 'v2.*', 'do': 'make install_jsregexp'} " Required by `lsp-zero`
+Plug 'L3MON4D3/LuaSnip', {'tag': 'v2.*', 'do': 'make install_jsregexp'}
 Plug 'rafamadriz/friendly-snippets' " snippet collection.
 Plug 'benfowler/telescope-luasnip.nvim' " List snippets with Telescope.
 
-Plug 'neovim/nvim-lspconfig', NeoVimButNoNoVSCode()                     " Required by `lsp-zero`
-Plug 'hrsh7th/nvim-cmp', NeoVimButNoNoVSCode()                          " Required by `lsp-zero`
-Plug 'hrsh7th/cmp-nvim-lsp', NeoVimButNoNoVSCode()                      " Required by `lsp-zero`
+Plug 'neovim/nvim-lspconfig', NeoVimButNoNoVSCode()
+Plug 'hrsh7th/nvim-cmp', NeoVimButNoNoVSCode()
+Plug 'hrsh7th/cmp-nvim-lsp', NeoVimButNoNoVSCode()
 Plug 'saadparwaiz1/cmp_luasnip', NeoVimButNoNoVSCode() " Add luasnips to cmp.
 Plug 'FelipeLema/cmp-async-path', NeoVimButNoNoVSCode() " Autocomplete file system paths.
-Plug 'VonHeikemen/lsp-zero.nvim', {'branch': 'v3.x'}
 
 Plug 'mfussenegger/nvim-lint', NeoVimButNoNoVSCode()
 


### PR DESCRIPTION
- **Fix: gitignore /autoload/plug.vim pattern**
- **Remove eslint from LSP config**
- **Fix: Skip Deno LSP setup if deno (1) not available**
- **Feat: Add Python LSP support via Pyright**
- **Feat: Add tailwind LSP support**
- **Fix: Remove deprecated lsp-zero**
- **Fix: Add line breaks to a Nix snippet**
- **Refactor: Remove dead code.**
- **Extend LSP capabilities with cmp-nvim-lsp**
- **Lua LS: Scan nvim's runtimepath**
- **LSP: Setup "default" lsp mappings**
