### PR TITLE
Disable spell checker for Lua files

### DIFF
--- a/ftplugin/lua.vim
+++ b/ftplugin/lua.vim
@@ -1,1 +1,2 @@
 setlocal ts=2 sts=2 sw=2 expandtab
+setlocal nospell " The spellchecker goes crazy with Lua files IDK why.


### PR DESCRIPTION
IDK the reason, but the spellchecker starts marking all words with
spelling / grammar mistakes. This commit sets `nospell` for Lua buffers.
I don't think debugging this is worth the time TBH.
