### PR TITLE
fix: Remove leader and local-leader remaps from lazy.nvim setup module

### DIFF
--- a/lua/config/lazy.lua
+++ b/lua/config/lazy.lua
@@ -17,11 +17,9 @@ if not (vim.uv or vim.loop).fs_stat(lazypath) then
 end
 vim.opt.rtp:prepend(lazypath)
 
--- Make sure to setup `mapleader` and `maplocalleader` before
--- loading lazy.nvim so that mappings are correct.
--- This is also a good place to setup other settings (vim.opt)
-vim.g.mapleader = " "
-vim.g.maplocalleader = "\\"
+-- Make sure to setup `mapleader` and `maplocalleader` before loading lazy.nvim
+-- so that mappings are correct. As of 2025-09-27, this is taken care at
+-- `init.vim`.
 
 -- Setup lazy.nvim
 require("lazy").setup({


### PR DESCRIPTION
CLOSES #44
