### PR TITLE
fix(base16): Fix comment highlight background

### DIFF
--- a/after/plugin/base16.vim
+++ b/after/plugin/base16.vim
@@ -43,7 +43,7 @@ endfunction
 
 function! s:base16_colorscheme_enhancements() abort
   " == General text highlighting ==
-  call <sid>hi("Comment", s:comment_fg, s:default_bg, "italic")
+  call <sid>hi("Comment", s:comment_fg, "NONE", "italic")
 
 
   " == General layout ==


### PR DESCRIPTION
I mistakenly set the Comment highlight group background color to the
default background instead to `NONE`, thus making it overrid the current
line background color.
