### PR TITLE
Fix reversed diagnostic jump direction

### DIFF
--- a/plugin/lsp.lua
+++ b/plugin/lsp.lua
@@ -16,10 +16,11 @@ vim.api.nvim_create_autocmd("LspAttach", {
     vim.keymap.set("n", "<leader>rn", vim.lsp.buf.rename, { buffer = event.buf, desc = "Rename symbol" })
 
     vim.keymap.set("n", "[d", function()
-      vim.diagnostic.jump({ count = 1, float = true })
-    end)
-    vim.keymap.set("n", "]d", function()
       vim.diagnostic.jump({ count = -1, float = true })
+    end)
+
+    vim.keymap.set("n", "]d", function()
+      vim.diagnostic.jump({ count = 1, float = true })
     end)
   end,
 })

--- a/plugin/lsp.lua
+++ b/plugin/lsp.lua
@@ -14,14 +14,6 @@ vim.api.nvim_create_autocmd("LspAttach", {
     vim.keymap.set({ "n", "x" }, "<F3>", vim.lsp.buf.format, opts)
     vim.keymap.set("n", "<F4>", vim.lsp.buf.code_action, opts)
     vim.keymap.set("n", "<leader>rn", vim.lsp.buf.rename, { buffer = event.buf, desc = "Rename symbol" })
-
-    vim.keymap.set("n", "[d", function()
-      vim.diagnostic.jump({ count = -1, float = true })
-    end)
-
-    vim.keymap.set("n", "]d", function()
-      vim.diagnostic.jump({ count = 1, float = true })
-    end)
   end,
 })
 


### PR DESCRIPTION
I had a bug on my `[d` and `]d` declarations. Turns out these are defined by
default. This is a good example of why code is a liability ;)

- **Fix diagnostic jump direction**
- **Remove redundant `[d` and `]d` mappings**
